### PR TITLE
FIX: Escape newlines in comments

### DIFF
--- a/niviz_rater/models.py
+++ b/niviz_rater/models.py
@@ -89,7 +89,7 @@ class Entity(TableMixin, db.Model):
         return (
             rating,
             self.has_failed,
-            self.comment or ""
+            self.comment.replace("\n","\\n") or ""
         )
 
 


### PR DESCRIPTION
Fixes newline characters in comments resulting in breaking up a single record into multiple rows